### PR TITLE
Fall back to project name when Sanity project ID is missing

### DIFF
--- a/src/common/sanityLoader.ts
+++ b/src/common/sanityLoader.ts
@@ -82,7 +82,7 @@ export async function LoadProjects(member: Member): Promise<{ [key: string]: Pro
             params: { ownerId: member._id },
         });
         return Object.fromEntries(
-            projects.map((project) => [project.id, mapProject(project)])
+            projects.map((project) => [project.id || project.name, mapProject(project)])
         );
     } catch (e) {
         console.error('Failed to load projects from Sanity:', e);


### PR DESCRIPTION
The deployed Sanity Studio may not have the Project ID field. Use project.name as fallback key for matching projects to directories.

https://claude.ai/code/session_01PRWFCcMRgaafKr2jGZKrpy